### PR TITLE
R Bump flyway fra 10.1.0 til 10.2.0 for å støtte høyere versjon av Postgres

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,8 +36,8 @@ dependencies {
     implementation("org.threeten:threeten-extra:1.7.2")
 
     implementation("org.flywaydb:flyway-core:10.2.0")
-    // implementation("com.zaxxer:HikariCP:5.0.1")
-    implementation("com.zaxxer:HikariCP-java7:2.4.13")
+    implementation("com.zaxxer:HikariCP:5.1.0")
+    //implementation("com.zaxxer:HikariCP-java7:2.4.13")
 
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.4")
     runtimeOnly("ch.qos.logback:logback-classic:1.4.14")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,9 +36,7 @@ dependencies {
     implementation("org.threeten:threeten-extra:1.7.2")
 
     implementation("org.flywaydb:flyway-database-postgresql:10.2.0")
-    implementation("org.flywaydb:flyway-core:10.2.0")
     implementation("com.zaxxer:HikariCP:5.1.0")
-    //implementation("com.zaxxer:HikariCP-java7:2.4.13")
 
     runtimeOnly("net.logstash.logback:logstash-logback-encoder:7.4")
     runtimeOnly("ch.qos.logback:logback-classic:1.4.14")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation("org.quartz-scheduler:quartz:2.3.2")
     implementation("org.threeten:threeten-extra:1.7.2")
 
+    implementation("org.flywaydb:flyway-database-postgresql:10.2.0")
     implementation("org.flywaydb:flyway-core:10.2.0")
     implementation("com.zaxxer:HikariCP:5.1.0")
     //implementation("com.zaxxer:HikariCP-java7:2.4.13")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("org.quartz-scheduler:quartz:2.3.2")
     implementation("org.threeten:threeten-extra:1.7.2")
 
-    implementation("org.flywaydb:flyway-core:10.1.0")
+    implementation("org.flywaydb:flyway-core:10.2.0")
     // implementation("com.zaxxer:HikariCP:5.0.1")
     implementation("com.zaxxer:HikariCP-java7:2.4.13")
 


### PR DESCRIPTION
## Beskrivelse
Flyway er bumpet fra 10.1.0 til 10.2.0 og HikariCp til 5.1.0

## Kommentarer
Vi får denne meldingen ved kjøring av flyway : "Uncaught exception in thread main: Unsupported Database: PostgreSQL 14.9"
Bumper versjonen til en nyere for å se om det hjelper
